### PR TITLE
refactor: Remove 'Real-time' tag from Docsapp project

### DIFF
--- a/pages/works.js
+++ b/pages/works.js
@@ -81,7 +81,7 @@ const Works = () => (
             id="docsapp"
             title="Docsapp"
             thumbnail={thumbInkdrop}
-            tags={['Real-time', 'Collaboration', 'Editor']}
+            tags={['Collaboration', 'Editor']}
           >
             Document App like Google Docs used to take notes edit documents in realtime
           </WorkGridItem>


### PR DESCRIPTION
Updated Docsapp tags from ['Real-time', 'Collaboration', 'Editor'] to ['Collaboration', 'Editor'] to simplify project categorization.