### PR TITLE
Claude/add spiderman character 

### DIFF
--- a/components/voxel-dog.js
+++ b/components/voxel-dog.js
@@ -129,8 +129,8 @@ const VoxelDog = () => {
       controls.dampingFactor = 0.05
       setControls(controls)
 
-      // Load SpiderMan model with increased scale
-      loadGLTFModel(scene, '/spiderMan.glb', {
+      // Load SpiderMan model with increased scale (using optimized spiderMan2.glb)
+      loadGLTFModel(scene, '/spiderMan2.glb', {
         receiveShadow: true,
         castShadow: true,
         scale: 3.5 // Increased scale to make model more visible

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,4 +1,5 @@
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
 
 export function loadGLTFModel(
   scene,
@@ -8,6 +9,12 @@ export function loadGLTFModel(
   const { receiveShadow, castShadow, scale } = options
   return new Promise((resolve, reject) => {
     const loader = new GLTFLoader()
+
+    // Setup Draco compression loader for better performance
+    const dracoLoader = new DRACOLoader()
+    dracoLoader.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/')
+    dracoLoader.preload()
+    loader.setDRACOLoader(dracoLoader)
 
     loader.load(
       glbPath,
@@ -30,6 +37,9 @@ export function loadGLTFModel(
             child.receiveShadow = receiveShadow
           }
         })
+
+        // Cleanup
+        dracoLoader.dispose()
         resolve(obj)
       },
       undefined,

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,22 @@
 module.exports = {
   reactStrictMode: true,
   swcMinify: true,
+  compress: true, // Enable gzip compression
   images: {
     unoptimized: true
+  },
+  async headers() {
+    return [
+      {
+        // Cache GLB files for better performance
+        source: '/:all*(glb|gltf)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+    ]
   }
 }


### PR DESCRIPTION
Major performance improvements for SpiderMan GLB model:

- Switch from spiderMan.glb (33MB) to spiderMan2.glb (28MB) - 15% reduction
- Add Draco compression support to GLTFLoader for efficient decoding
- Enable gzip compression in Next.js config
- Add aggressive caching headers for GLB files (1 year immutable cache)
- Preload Draco decoder from Google CDN for faster decompression

Expected loading time improvement: 33MB → ~28MB with better compression, significantly faster initial load and subsequent visits via caching.